### PR TITLE
Prevent demosys from crashing if incorrect shader is reloaded.

### DIFF
--- a/demosys/resources/shaders.py
+++ b/demosys/resources/shaders.py
@@ -47,7 +47,10 @@ class Shaders:
                 if path:
                     print(" - {}".format(path))
                     shader.set_source(open(path, 'r').read())
-                    shader.prepare()
+                    try:
+                        shader.prepare()
+                    except Exception as err:
+                        print(err)
                     break
             else:
                 raise ImproperlyConfigured("Cannot find shader {}".format(name))


### PR DESCRIPTION
I did open issue for this, but then I realized that I can fix this by myself. 