### PR TITLE
Include uniform time from python code to default shader.

### DIFF
--- a/demosys/effects/default/effect.py
+++ b/demosys/effects/default/effect.py
@@ -29,4 +29,5 @@ class DefaultEffect(effect.Effect):
             shader.uniform_mat4("m_proj", self.sys_camera.projection.matrix)
             shader.uniform_mat4("m_mv", m_mv)
             shader.uniform_mat3("m_normal", m_normal)
+            shader.uniform_1f("time", time)
         self.cube.draw()

--- a/demosys/effects/default/shaders/default/default.glsl
+++ b/demosys/effects/default/shaders/default/default.glsl
@@ -28,7 +28,7 @@ void main()
 {
     vec3 dir = vec3(0.0, 0.0, 1.0);
     float l = dot(dir, normal);
-    fragColor = vec4(l);
+    fragColor = vec4(l, sin(time), l * 2.0, 1.0);
 }
 
 #endif


### PR DESCRIPTION
I found it quite strange that uniform float time was available in default shader, but it was not used at all and it was not bound from python code. So I modified default shader and default effect python code to use time variable. 