### PR TITLE
Simplify a ridiculous way of generating a settings file

### DIFF
--- a/demosys/conf/__init__.py
+++ b/demosys/conf/__init__.py
@@ -4,7 +4,7 @@ Settings and configuration for demosys
 import importlib
 import os
 
-from demosys.conf import default_settings
+from demosys.conf import default
 from demosys.core.exceptions import ImproperlyConfigured
 
 ENVIRONMENT_VARIABLE = "DEMOSYS_SETTINGS_MODULE"
@@ -13,10 +13,11 @@ ENVIRONMENT_VARIABLE = "DEMOSYS_SETTINGS_MODULE"
 
 
 class Settings:
+    SETTINGS_MODULE = None
     SHADER_DIRS = []
     TEXTURE_DIRS = []
     DATA_DIRS = []
-    SETTINGS_MODULE = None
+    SCENE_DIRS = []
 
     def __init__(self):
         settings_module = os.environ.get(ENVIRONMENT_VARIABLE)
@@ -27,9 +28,9 @@ class Settings:
             )
 
         # Update this dict from global settings
-        for setting in dir(default_settings):
+        for setting in dir(default):
             if setting.isupper():
-                setattr(self, setting, getattr(default_settings, setting))
+                setattr(self, setting, getattr(default, setting))
 
         # Read the supplied settings module
         self.SETTINGS_MODULE = settings_module

--- a/demosys/conf/default.py
+++ b/demosys/conf/default.py
@@ -1,32 +1,8 @@
-"""
-Default settings for demosys. Override using a settings module.
-"""
+import os
 
-# What attributes should be used when generating a settings file
-__ORDER__ = (
-    'DEBUG',
-    'SCREENSHOT_PATH',
-    'OPENGL',
-    'WINDOW',
-    'MUSIC',
-    'TIMER',
-    'ROCKET',
-    'EFFECTS',
-    'EFFECT_MANAGER',
-    'SHADER_DIRS',
-    'SHADER_FINDERS',
-    'TEXTURE_DIRS',
-    'TEXTURE_FINDERS',
-    'SCENE_DIRS',
-    'SCENE_FINDERS',
-    'SCENE_LOADERS',
-    'DATA_DIRS',
-    'DATA_FINDERS',
-)
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DEBUG = False
-
-SCREENSHOT_PATH = None
+SCREENSHOT_PATH = os.path.join(PROJECT_DIR, 'screenshots')
 
 # OpenGL context configuration
 # version: (MAJOR, MINOR)
@@ -34,7 +10,7 @@ OPENGL = {
     "version": (3, 3),
 }
 
-# Window size
+# Window / context properties
 WINDOW = {
     "class": "demosys.context.glfw.GLFW_Window",
     "size": (1280, 720),
@@ -63,7 +39,7 @@ EFFECTS = ()
 
 EFFECT_MANAGER = 'demosys.effects.managers.SingleEffectManager'
 
-# Raise errors when uniforms are assigned with incorrect type
+# Raise errors when shader uniforms are assigned incorrectly
 # Otherwise just print the errors to terminal
 SHADER_STRICT_VALIDATION = False
 
@@ -73,23 +49,22 @@ SHADERS = {
     'geometry_shader_suffix': ('geom', '_gs.glsl', '.glslg'),
 }
 
-# Additional directories shaders can be found
 SHADER_DIRS = ()
 
-# Finder
 SHADER_FINDERS = (
     'demosys.core.shaderfiles.finders.FileSystemFinder',
     'demosys.core.shaderfiles.finders.EffectDirectoriesFinder'
 )
 
-# Additonal directories textures can be found
 TEXTURE_DIRS = ()
+
 TEXTURE_FINDERS = (
     'demosys.core.texturefiles.finders.FileSystemFinder',
     'demosys.core.texturefiles.finders.EffectDirectoriesFinder'
 )
 
 SCENE_DIRS = ()
+
 SCENE_FINDERS = (
     "demosys.core.scenefiles.finders.FileSystemFinder",
     "demosys.core.scenefiles.finders.EffectDirectoriesFinder",
@@ -101,6 +76,7 @@ SCENE_LOADERS = (
 )
 
 DATA_DIRS = ()
+
 DATA_FINDERS = (
     "demosys.core.datafiles.finders.FileSystemFinder",
     "demosys.core.datafiles.finders.EffectDirectoriesFinder",

--- a/demosys/conf/settingsfile.py
+++ b/demosys/conf/settingsfile.py
@@ -1,45 +1,19 @@
+import os
 
 
-def create(settings):
+def create(**kwargs):
     """
-    Return a string representation of the settings.
-    This is an extremely ugly way of doing this, but it works for now!
+    Return a string representing a new default settings file for a project
     """
-    # FIXME: Use a template system for generating settings file
-    data = "# Auto generated settings file\n" \
-           "import os\n" \
-           "PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))\n\n"
+    template_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default.py')
+    data = ""
+    with open(template_file, 'r') as fd:
+        data = fd.read()
 
-    for name in settings.__ORDER__:
-        value = getattr(settings, name)
+    header = (
+        '"""\n'
+        'Auto generated settings file for project {}\n'
+        '"""\n'
+    ).format(kwargs.get('name'))
 
-        if isinstance(value, dict):
-            value = ",\n".join('    "{}": {}'.format(k, to_s(v)) for k, v in value.items())
-
-            # Add comma after the last dict entry
-            if value:
-                value += ','
-
-            data += "%s = {\n%s\n}\n\n" % (name, value)
-
-        elif isinstance(value, tuple):
-            value = ",\n".join("    {}".format(to_s(v)) for v in value)
-
-            # Add comma after the last tuple entry
-            if value:
-                value += ","
-
-            data += "{} = (\n{}\n)\n\n".format(name, value)
-
-        elif value is None:
-            data += "{} = {}\n\n".format(name, value)
-
-    # Return config excluding last newline
-    return data[:-1]
-
-
-def to_s(var):
-    if isinstance(var, str):
-        return '"{}"'.format(var)
-    else:
-        return str(var)
+    return header + data

--- a/demosys/core/management/commands/createproject.py
+++ b/demosys/core/management/commands/createproject.py
@@ -31,12 +31,11 @@ class Command(CreateCommand):
         os.makedirs(name)
 
         # Use the default settings file
-        os.environ['DEMOSYS_SETTINGS_MODULE'] = 'demosys.conf.default_settings'
-        from demosys.conf import settings
+        os.environ['DEMOSYS_SETTINGS_MODULE'] = 'demosys.conf.default'
         from demosys.conf import settingsfile
 
         with open(os.path.join(name, 'settings.py'), 'w') as fd:
-            fd.write(settingsfile.create(settings))
+            fd.write(settingsfile.create(name=name))
 
         with open(manage_file, 'w') as fd:
             fd.write(gen_manage_py(name))


### PR DESCRIPTION
This was implemented in a really silly way. Keep things simple.

The default effect module can also just be the file we copy when generating a project. There is no need to overly complicate this with a templating system or anything like that. We simply just add a header to the file with the project name.